### PR TITLE
fix: correct LightControl config reference

### DIFF
--- a/Live Files/Live-CTRL-LightControl.js
+++ b/Live Files/Live-CTRL-LightControl.js
@@ -79,7 +79,7 @@ const LightControl = {
 
             let wallID = args[1];
             let action = args[2].toLowerCase();
-            let gridSize = args[3] ? parseInt(args[3], 10) : LightingControl.config.DEFAULT_GRID_SIZE;
+            let gridSize = args[3] ? parseInt(args[3], 10) : LightControl.config.DEFAULT_GRID_SIZE;
             let gridsToMove = args[4] ? parseInt(args[4], 10) : 1;
             let totalMove = gridSize * gridsToMove;
 


### PR DESCRIPTION
## Summary
- fix reference to default grid size in `processWallCommand`

## Testing
- `node - <<'NODE'
 global.log = function(){};
 global.sendChat = function(){};
 global.playerIsGM = function(){return true;};
 global.getObj = function(){return {get:function(){return 0;}, set:function(){}}};
 global.findObjs = function(){return [];};
 global.Campaign = function(){return {get:function(){return 0;}}};
 global.on = function(){};
 global.state = {};
 require('./Live Files/Live-CTRL-LightControl.js');
 console.log('Loaded OK');
NODE

------
https://chatgpt.com/codex/tasks/task_e_68526a1a28a4832a9f3123a967796193