### PR TITLE
fix: correct help label in CommandMenu

### DIFF
--- a/Live Files/Live-CommandMenu.js
+++ b/Live Files/Live-CommandMenu.js
@@ -377,7 +377,7 @@ const CommandMenu = {
                 case CommandMenu.config.MENU_SECTIONS.SYSTEM:
                     return "{{System Operations=[" +
                            "⚙️ Main Menu](!menu)" +                  // Returns to the full main menu
-                           "[❓ CommandPanel Help](!menu help)" +     // Shows CommandMenu's own help
+                           "[❓ CommandMenu Help](!menu help)" +     // Shows CommandMenu's own help
                            // APIHeartBeat Integration
                            "[💓 API Status Check](!api-heartbeat --check)" +        // Quick check if API is responsive
                            "[📊 API Latency Graph](!api-heartbeat --histogram)" +  // Shows latency graph (GM useful)


### PR DESCRIPTION
## Summary
- update the help link text in the system menu from **CommandPanel** to **CommandMenu**

## Testing
- `grep -n "CommandMenu Help" -n "Live Files/Live-CommandMenu.js"`

------
https://chatgpt.com/codex/tasks/task_e_685281c6cee4832a96c3957f892a3ddd