### PR TITLE
Implement auto-trigger in manualTrigger

### DIFF
--- a/Live Files/Live-SYS-TrapSystem.js
+++ b/Live Files/Live-SYS-TrapSystem.js
@@ -2826,12 +2826,21 @@ const TrapSystem = {
                     TrapSystem.utils.sendDepletedMessage(trapToken);
                 }
 
+                // Determine correct aura color based on trap type
+                const isInteraction = trapData.type === 'interaction';
+                let auraColor;
+                if (stillArmed) {
+                    if (TrapSystem.state.triggersEnabled) {
+                        auraColor = isInteraction ? TrapSystem.config.AURA_COLORS.ARMED_INTERACTION : TrapSystem.config.AURA_COLORS.ARMED;
+                    } else {
+                        auraColor = TrapSystem.config.AURA_COLORS.PAUSED;
+                    }
+                } else {
+                    auraColor = isInteraction ? TrapSystem.config.AURA_COLORS.DISARMED_INTERACTION : TrapSystem.config.AURA_COLORS.DISARMED;
+                }
+
                 trapToken.set({
-                    aura1_color: stillArmed
-                        ? (TrapSystem.state.triggersEnabled
-                            ? TrapSystem.config.AURA_COLORS.ARMED
-                            : TrapSystem.config.AURA_COLORS.PAUSED)
-                        : TrapSystem.config.AURA_COLORS.DISARMED,
+                    aura1_color: auraColor,
                     aura1_radius: TrapSystem.utils.calculateDynamicAuraRadius(trapToken),
                     showplayers_aura1: false
                 });

--- a/Live Files/Live-SYS-TrapSystem.js
+++ b/Live Files/Live-SYS-TrapSystem.js
@@ -2446,6 +2446,13 @@ const TrapSystem = {
                 return;
             }
 
+            if (trapData.autoTrigger &&
+                trapData.primaryMacro &&
+                trapData.primaryMacro.macro) {
+                this.manualMacroTrigger(trapToken.id, trapData.primaryMacro.macro);
+                return;
+            }
+
             // If "interaction" type, show interaction menu regardless of armed state.
             // The menu itself will handle showing/hiding action buttons.
             if (trapData.type === 'interaction') {
@@ -2808,21 +2815,26 @@ const TrapSystem = {
                 TrapSystem.utils.chat('❌ Error: Trap cannot be triggered (disarmed or no uses)');
                 return;
             }
-            // Run the macro
+
             const tagToIdMap = TrapSystem.utils.buildTagToIdMap(trapToken, null, null);
             const macroExecuted = TrapSystem.utils.executeMacro(macroName, tagToIdMap);
             if (macroExecuted) {
-                // Lower the use
                 const newUses = trapData.currentUses - 1;
-                TrapSystem.utils.updateTrapUses(trapToken, newUses, trapData.maxUses);
-                if (newUses <= 0) {
+                const stillArmed = newUses > 0;
+                TrapSystem.utils.updateTrapUses(trapToken, newUses, trapData.maxUses, stillArmed);
+                if (!stillArmed) {
                     TrapSystem.utils.sendDepletedMessage(trapToken);
-                    trapToken.set({
-                        aura1_color: TrapSystem.config.AURA_COLORS.DISARMED,
-                        aura1_radius: TrapSystem.utils.calculateDynamicAuraRadius(token),
-                        showplayers_aura1: false
-                    });
                 }
+
+                trapToken.set({
+                    aura1_color: stillArmed
+                        ? (TrapSystem.state.triggersEnabled
+                            ? TrapSystem.config.AURA_COLORS.ARMED
+                            : TrapSystem.config.AURA_COLORS.PAUSED)
+                        : TrapSystem.config.AURA_COLORS.DISARMED,
+                    aura1_radius: TrapSystem.utils.calculateDynamicAuraRadius(trapToken),
+                    showplayers_aura1: false
+                });
             } else {
                 TrapSystem.utils.chat('❌ Failed to execute the macro.');
             }


### PR DESCRIPTION
## Summary
- add auto-trigger check in `manualTrigger` so primary macro runs automatically when autoTrigger is set
- fix a bad variable reference in `manualMacroTrigger`
- ensure manual macro triggers update armed state and aura like other trigger paths

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853c4d00794832aa539e350574cf777