### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete string escaping or encoding

### DIFF
--- a/Live Files/Live-SYS-TrapSystem.js
+++ b/Live Files/Live-SYS-TrapSystem.js
@@ -2772,7 +2772,7 @@ const TrapSystem = {
                 }
 
                 if (content.startsWith('&{')) { // This is a roll template
-                    return `"${content.replace(/"/g, '\\"')}"`; // Quote and escape
+                    return `"${content.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`; // Quote and escape backslashes and double quotes
                 }
                 if (content.startsWith('!')) {
                     return `"$${content.substring(1)}"`;


### PR DESCRIPTION
Potential fix for [https://github.com/LordFarquaad-RJB/Cursor---Coding/security/code-scanning/12](https://github.com/LordFarquaad-RJB/Cursor---Coding/security/code-scanning/12)

To fix the issue, the `content.replace` call should be updated to escape both double quotes and backslashes. This can be achieved by using a regular expression that matches both characters and replaces them appropriately. Specifically, the replacement should ensure that backslashes are escaped before escaping double quotes. This ensures that the escaping process is complete and robust.

The fix involves modifying the `content.replace` call on line 2775 to use a regular expression that handles both backslashes and double quotes. The updated code will replace each backslash with two backslashes and each double quote with an escaped double quote.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
