### PR TITLE
Potential fix for code scanning alert no. 10: Double escaping or unescaping

### DIFF
--- a/Live Files/Live-SYS-TrapSystem.js
+++ b/Live Files/Live-SYS-TrapSystem.js
@@ -253,11 +253,11 @@ const TrapSystem = {
 
         decodeHtml(text) {
             if (typeof text !== 'string') return text;
-            return text.replace(/&amp;/g, '&')
-                       .replace(/&lt;/g, '<')
+            return text.replace(/&lt;/g, '<')
                        .replace(/&gt;/g, '>')
                        .replace(/&quot;/g, '"')
-                       .replace(/&#39;/g, "'");
+                       .replace(/&#39;/g, "'")
+                       .replace(/&amp;/g, '&');
         },
 
         // Return a sanitized token image URL or a fallback icon


### PR DESCRIPTION
Potential fix for [https://github.com/LordFarquaad-RJB/Cursor---Coding/security/code-scanning/10](https://github.com/LordFarquaad-RJB/Cursor---Coding/security/code-scanning/10)

To fix the issue, the `decodeHtml` function should unescape the `&amp;` entity last. This ensures that the escape character `&` is not prematurely unescaped, preventing double unescaping of other entities. The fix involves reordering the `.replace()` calls so that `text.replace(/&amp;/g, '&')` is the last replacement in the chain.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
